### PR TITLE
Added option to supply a formatting function, instead of prepend or append

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,18 @@ var PluginError = gutil.PluginError;
 function concatFilenames(filename, opts) {
     'use strict';
 
+    var identity = function(x) {
+        return x;
+    };
+
     var error = {
         noFilename: 'Missing fileName option for gulp-concat-filenames',
         noStreaming: 'Streaming not supported'
     };
 
     opts = opts || {};
-    
+    opts.template = opts.template || identity;
+
     if (!filename) {
         throw new PluginError('gulp-concat-filenames', error.noFilename);
     }
@@ -46,7 +51,7 @@ function concatFilenames(filename, opts) {
 
         var thisRequire = [
                     opts.prepend || '',
-                    requirePath.replace(/\\/g, '\/'),
+                    opts.template(requirePath.replace(/\\/g, '\/')),
                     opts.append || '',
                     opts.newLine
                 ].join('');

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ function concatFilenames(filename, opts) {
 
     var error = {
         noFilename: 'Missing fileName option for gulp-concat-filenames',
-        noStreaming: 'Streaming not supported'
+        noStreaming: 'Streaming not supported',
+        badTemplate: 'Error in template function'
     };
 
     opts = opts || {};
@@ -44,6 +45,21 @@ function concatFilenames(filename, opts) {
 
         var requirePath = path.resolve(file.path);
 
+        // Make sure template errors reach the output
+        var safeTemplate = function(str) {
+            var output;
+            try {
+                output = opts.template(str);
+            } catch (e) {
+                e.message = error.badTemplate + ': ' + e.message;
+                return this.emit('error', new PluginError('gulp-concat-filenames', e));
+            }
+
+            if (typeof output !== 'string') {
+                return this.emit('error', new PluginError('gulp-concat-filenames', error.badTemplate));
+            }
+            return output;
+        };
 
         requirePath = opts.root ?
             path.relative(opts.root, requirePath) :
@@ -51,7 +67,7 @@ function concatFilenames(filename, opts) {
 
         var thisRequire = [
                     opts.prepend || '',
-                    opts.template(requirePath.replace(/\\/g, '\/')),
+                    safeTemplate.call(this, requirePath.replace(/\\/g, '\/')),
                     opts.append || '',
                     opts.newLine
                 ].join('');

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,8 @@ The second argument is optional, and is an object with the following properties:
 
 - `append` - Some text to append to every intry in the list of filenames
 
+- `template` - a function that takes one parameter (the file name) and returns the string after some formatting. Can be used in addition to, or instead of, `append` and `prepend`
+
 - `root` - the root folder. Including this argument will return a list of relative paths instead of absolute paths.
 
 

--- a/test/main.js
+++ b/test/main.js
@@ -178,6 +178,43 @@ describe('Given gulp-concat-filenames', function () {
                         .pipe(assert.end(done));
                 });
             });
+
+            describe('When I provide a formatting function with a syntax error', function () {
+
+                it('then it will fail and throw an error', function (done) {
+                    gulp
+                        .src(fixtures('*'))
+                        .pipe(concatFilenames('mainfest.txt', {
+                            root: 'fixtures',
+                            template: function(filename) {
+                                y = 0;
+                                return filename;
+                            }
+                        }))
+                        .on('error', function (err) {
+                            expect(err.message).to.have.string('Error in template function');
+                            done();
+                        });
+                });
+            });
+
+            describe('When I provide a formatting function that does not return a string', function () {
+
+                it('then it will fail and throw an error', function (done) {
+                    gulp
+                        .src(fixtures('*'))
+                        .pipe(concatFilenames('mainfest.txt', {
+                            root: 'fixtures',
+                            template: function(filename) {
+                                return 5;
+                            }
+                        }))
+                        .on('error', function (err) {
+                            expect(err.message).to.equal('Error in template function');
+                            done();
+                        });
+                });
+            });
         });
     });
 });

--- a/test/main.js
+++ b/test/main.js
@@ -150,6 +150,34 @@ describe('Given gulp-concat-filenames', function () {
                         .pipe(assert.end(done));
                 });
             });
+
+            describe('When I provide a formatting function', function () {
+
+                it('then it will apply that function to each entry', function (done) {
+                    var expectedFilenames = ([
+                        'XXX../test/fixtures/fork.txtYYY',
+                        'XXX../test/fixtures/knife.jsYYY',
+                        'XXX../test/fixtures/spoon.htmlYYY',
+                    ].join('\n') + '\n').toString().toUpperCase();
+
+                    gulp
+                        .src(fixtures('*'))
+                        .pipe(concatFilenames('mainfest.txt', {
+                            root: 'fixtures',
+                            template: function(filename) {
+                                return 'XXX' + filename.toUpperCase() + 'YYY';
+                            }
+                        }))
+                        .pipe(assert.first(function (d) {
+
+                            var contents = d.contents.toString();
+                            expect(contents)
+                                .to
+                                .equal(expectedFilenames);
+                        }))
+                        .pipe(assert.end(done));
+                });
+            });
         });
     });
 });

--- a/test/main.js
+++ b/test/main.js
@@ -187,7 +187,9 @@ describe('Given gulp-concat-filenames', function () {
                         .pipe(concatFilenames('mainfest.txt', {
                             root: 'fixtures',
                             template: function(filename) {
-                                y = 0;
+                                /* jshint ignore:start */
+                                y = 0; // deliberate syntax error
+                                /* jshint ignore:end */
                                 return filename;
                             }
                         }))
@@ -205,7 +207,7 @@ describe('Given gulp-concat-filenames', function () {
                         .src(fixtures('*'))
                         .pipe(concatFilenames('mainfest.txt', {
                             root: 'fixtures',
-                            template: function(filename) {
+                            template: function() {
                                 return 5;
                             }
                         }))


### PR DESCRIPTION
Reasons it's useful:

- Can use a template where the name appears more than once
- If you want to template something that has structure / symmetry, then it's far easier to avoid mistakes
- Lets you throw out unneeded parts of the filename

100% backwards compatible and doesn't interfere with anything