### PR TITLE
It should support null or streamd files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
+  - node
 after_script:
   - npm run coveralls

--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ function concatFilenames(filename, opts) {
 
     var error = {
         noFilename: 'Missing fileName option for gulp-concat-filenames',
-        noStreaming: 'Streaming not supported',
         badTemplate: 'Error in template function'
     };
 
@@ -32,15 +31,6 @@ function concatFilenames(filename, opts) {
         firstfile;
 
     function bufferContents(file) {
-        if (file.isNull()) {
-            return;
-        }
-
-        if (file.isStream()) {
-            var errorNoStream = new PluginError('gulp-concat-filenames', error.noStreaming);
-            return this.emit('error', errorNoStream);
-        }
-
         firstfile = firstfile || file;
 
         var requirePath = path.resolve(file.path);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   }, {
       "name" : "Noam Youngerman",
       "email" : "noam@younger.mn"
+  }, {
+      "name" : "Rainfore Zhao",
+      "email" : "rainforest92@126.com"
   }],
   "main": "./index.js",
   "keywords": [

--- a/test/main.js
+++ b/test/main.js
@@ -30,25 +30,54 @@ describe('Given gulp-concat-filenames', function () {
     });
 
     describe('When I do provide a filename', function () {
-        it('Then it should ignore null files', function (done) {
-            var stream = concatFilenames('example.js');
-            stream
-                .pipe(assert.length(0))
+        it('Then it should support null files', function (done) {
+            var expectedFilenames = ([
+                    path.join(__dirname, 'fixtures/fork.txt'),
+                    path.join(__dirname, 'fixtures/knife.js'),
+                    path.join(__dirname, 'fixtures/spoon.html'),
+                ]
+                    .join('\n') + '\n')
+                .replace(/\\/g, '\/')
+                .toString();
+
+            gulp
+                .src(fixtures('*'), {
+                    read: false
+                })
+                .pipe(concatFilenames('example.js'))
+                .pipe(assert.first(function (d) {
+
+                    var contents = d.contents.toString();
+                    expect(contents)
+                        .to
+                        .equal(expectedFilenames);
+                }))
                 .pipe(assert.end(done));
-            stream.write(new File());
-            stream.end();
         });
 
-        it('Then it emit an error in streamed files', function (done) {
+        it('Then it support streamed files', function (done) {
+            var expectedFilenames = ([
+                    path.join(__dirname, 'fixtures/fork.txt'),
+                    path.join(__dirname, 'fixtures/knife.js'),
+                    path.join(__dirname, 'fixtures/spoon.html'),
+                ]
+                    .join('\n') + '\n')
+                .replace(/\\/g, '\/')
+                .toString();
+
             gulp
                 .src(fixtures('*'), {
                     buffer: false
                 })
                 .pipe(concatFilenames('example.js'))
-                .on('error', function (err) {
-                    expect(err.message).to.equal('Streaming not supported');
-                    done();
-                });
+                .pipe(assert.first(function (d) {
+
+                    var contents = d.contents.toString();
+                    expect(contents)
+                        .to
+                        .equal(expectedFilenames);
+                }))
+                .pipe(assert.end(done));
         });
 
         describe('When I do not provide the "root" optional argument', function () {


### PR DESCRIPTION
We just need the filenames, not the contents. There is no reason to refuse these two kinds of files.

Sometimes it can be faster when setting `read: false` option, which makes files to be null. It's like using [gulp-rimraf](https://www.npmjs.com/package/gulp-rimraf).

```javascript
gulp.src(..., {read: false})
    .pipe(concatFilenames('example.js')
    ...
```

All the tests passed.